### PR TITLE
Lots of stuff worthy of a new release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /obj
 __pycache__
-smol-*-*-*/
-*.tar.xz
+
+smol-20*-*-*/
+smol*.tar.xz

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /bin
 /obj
 __pycache__
+smol-*-*-*/
+*.tar.xz

--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,12 @@ $(OBJDIR)/%.o: $(TESTDIR)/%.c $(OBJDIR)/
 	$(CC) $(CFLAGS) -c "$<" -o "$@"
 
 $(BINDIR)/%.dbg $(BINDIR)/%: $(OBJDIR)/%.o $(BINDIR)/
-	$(PYTHON3) ./smold.py --debugout $(SMOLFLAGS) --ldflags=-Wl,-Map=$(BINDIR)/$*.map $(LIBS) "$<" "$@.dbg"
+	$(PYTHON3) ./smold.py --debugout $(SMOLFLAGS) $(LIBS) "$<" "$@.dbg"
 	$(PYTHON3) ./smold.py $(SMOLFLAGS) --ldflags=-Wl,-Map=$(BINDIR)/$*.map $(LIBS) "$<" "$@"
 	$(PYTHON3) ./smoltrunc.py "$@" "$(OBJDIR)/$(notdir $@)" && mv "$(OBJDIR)/$(notdir $@)" "$@" && chmod +x "$@"
 
 $(BINDIR)/%-crt.dbg $(BINDIR)/%-crt: $(OBJDIR)/%.lto.o $(OBJDIR)/crt1.lto.o $(BINDIR)/
-	$(PYTHON3) ./smold.py --debugout $(SMOLFLAGS) --ldflags=-Wl,-Map=$(BINDIR)/$*-crt.map $(LIBS) "$<" $(OBJDIR)/crt1.lto.o "$@.dbg"
+	$(PYTHON3) ./smold.py --debugout $(SMOLFLAGS) $(LIBS) "$<" $(OBJDIR)/crt1.lto.o "$@.dbg"
 	$(PYTHON3) ./smold.py $(SMOLFLAGS) --ldflags=-Wl,-Map=$(BINDIR)/$*-crt.map $(LIBS) "$<" $(OBJDIR)/crt1.lto.o "$@"
 	$(PYTHON3) ./smoltrunc.py "$@" "$(OBJDIR)/$(notdir $@)" && mv "$(OBJDIR)/$(notdir $@)" "$@" && chmod +x "$@"
 

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,7 @@ LIBS = $(filter-out -pthread,$(shell pkg-config --libs sdl2)) -lX11 -lm -lc #-lG
 PWD ?= .
 
 SMOLFLAGS = --smolrt "$(PWD)/rt" --smolld "$(PWD)/ld" \
-     -falign-stack -fuse-interp -fifunc-support \
-     --verbose #--keeptmp
+    --verbose #--keeptmp
 # -fuse-dnload-loader -fskip-zero-value -fuse-nx -fskip-entries -fuse-dt-debug
 # -fuse-dl-fini -fno-start-arg -funsafe-dynamic
 

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ CXXOPTFLAGS=$(COPTFLAGS) -fno-exceptions \
   -fno-rtti -fno-enforce-eh-specs -fnothrow-opt -fno-use-cxa-get-exception-ptr \
   -fno-implicit-templates -fno-threadsafe-statics -fno-use-cxa-atexit
 
-CFLAGS=-Wall -Wextra -Wpedantic -std=gnu11 -nostartfiles -fno-PIC $(COPTFLAGS) #-DUSE_DL_FINI
-CXXFLAGS=-Wall -Wextra -Wpedantic -std=c++11 $(CXXOPTFLAGS) -nostartfiles -fno-PIC
+CFLAGS=-g -Wall -Wextra -Wpedantic -std=gnu11 -nostartfiles -fno-PIC $(COPTFLAGS) #-DUSE_DL_FINI
+CXXFLAGS=-g -Wall -Wextra -Wpedantic -std=c++11 $(CXXOPTFLAGS) -nostartfiles -fno-PIC
 
 CFLAGS   += -m$(BITS) $(shell pkg-config --cflags sdl2)
 CXXFLAGS += -m$(BITS) $(shell pkg-config --cflags sdl2)
@@ -41,7 +41,7 @@ LIBS = $(filter-out -pthread,$(shell pkg-config --libs sdl2)) -lX11 -lm -lc #-lG
 PWD ?= .
 
 SMOLFLAGS = --smolrt "$(PWD)/rt" --smolld "$(PWD)/ld" \
-    --verbose #--keeptmp
+    --verbose -g #--keeptmp
 # -fuse-dnload-loader -fskip-zero-value -fuse-nx -fskip-entries -fuse-dt-debug
 # -fuse-dl-fini -fno-start-arg -funsafe-dynamic
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ LIBS = $(filter-out -pthread,$(shell pkg-config --libs sdl2)) -lX11 -lm -lc #-lG
 PWD ?= .
 
 SMOLFLAGS = --smolrt "$(PWD)/rt" --smolld "$(PWD)/ld" \
-     -falign-stack -fuse-interp -fifunc-support \
+     -falign-stack -fuse-interp -fifunc-support -fskip-zero-value \
      --verbose #--keeptmp
 # -fuse-dnload-loader -fskip-zero-value -fuse-nx -fskip-entries -fuse-dt-debug
 # -fuse-dl-fini -fno-start-arg -funsafe-dynamic

--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,11 @@ $(OBJDIR)/%.o: $(TESTDIR)/%.c $(OBJDIR)/
 	$(CC) $(CFLAGS) -c "$<" -o "$@"
 
 $(BINDIR)/%.dbg $(BINDIR)/%: $(OBJDIR)/%.o $(BINDIR)/
-	$(PYTHON3) ./smold.py --debugout $(SMOLFLAGS) $(LIBS) "$<" "$@.dbg"
-	$(PYTHON3) ./smold.py $(SMOLFLAGS) --ldflags=-Wl,-Map=$(BINDIR)/$*.map $(LIBS) "$<" "$@"
+	$(PYTHON3) ./smold.py --debugout "$@.dbg" $(SMOLFLAGS) --ldflags=-Wl,-Map=$(BINDIR)/$*.map $(LIBS) "$<" "$@"
 	$(PYTHON3) ./smoltrunc.py "$@" "$(OBJDIR)/$(notdir $@)" && mv "$(OBJDIR)/$(notdir $@)" "$@" && chmod +x "$@"
 
 $(BINDIR)/%-crt.dbg $(BINDIR)/%-crt: $(OBJDIR)/%.lto.o $(OBJDIR)/crt1.lto.o $(BINDIR)/
-	$(PYTHON3) ./smold.py --debugout $(SMOLFLAGS) $(LIBS) "$<" $(OBJDIR)/crt1.lto.o "$@.dbg"
-	$(PYTHON3) ./smold.py $(SMOLFLAGS) --ldflags=-Wl,-Map=$(BINDIR)/$*-crt.map $(LIBS) "$<" $(OBJDIR)/crt1.lto.o "$@"
+	$(PYTHON3) ./smold.py --debugout "$@.dbg" $(SMOLFLAGS) --ldflags=-Wl,-Map=$(BINDIR)/$*-crt.map $(LIBS) "$<" $(OBJDIR)/crt1.lto.o "$@"
 	$(PYTHON3) ./smoltrunc.py "$@" "$(OBJDIR)/$(notdir $@)" && mv "$(OBJDIR)/$(notdir $@)" "$@" && chmod +x "$@"
 
 .PHONY: all clean

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ LIBS = $(filter-out -pthread,$(shell pkg-config --libs sdl2)) -lX11 -lm -lc #-lG
 PWD ?= .
 
 SMOLFLAGS = --smolrt "$(PWD)/rt" --smolld "$(PWD)/ld" \
-     -falign-stack -fuse-interp -fifunc-support -fskip-zero-value \
+     -falign-stack -fuse-interp -fifunc-support \
      --verbose #--keeptmp
 # -fuse-dnload-loader -fskip-zero-value -fuse-nx -fskip-entries -fuse-dt-debug
 # -fuse-dl-fini -fno-start-arg -funsafe-dynamic

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Shoddy minsize-oriented linker
 
-PoC by Shiz, bugfixing, 64-bit version and maintenance by PoroCYon,
-enhancements and bugfixes by blackle.
+PoC and maintenance by Shiz, bugfixing, 64-bit version and maintenance by
+PoroCYon, enhancements and bugfixes by blackle.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ PoC by Shiz, bugfixing and 64-bit version by PoroCYon.
 * GCC (not clang, as the latter doesn't support `nolto-rel` output), GNU ld,
   binutils, GNU make, ...
 * nasm 2.13 or newer
-* `scanelf` from `pax-utils`
 * Python 3
 
 ## Usage
@@ -25,7 +24,7 @@ the smol startup/symbol resolving code will jump to an undefined location.
 ```
 usage: smold.py [-h] [-m TARGET] [-l LIB] [-L DIR] [-s] [-n] [-d] [-fuse-interp] [-falign-stack] [-fuse-nx]
                 [-fuse-dnload-loader] [-fskip-zero-value] [-fuse-dt-debug] [-fuse-dl-fini] [-fskip-entries]
-                [-fno-start-arg] [-funsafe-dynamic] [--nasm NASM] [--cc CC] [--scanelf SCANELF] [--readelf READELF]
+                [-fno-start-arg] [-funsafe-dynamic] [--nasm NASM] [--cc CC] [--readelf READELF]
                 [--cflags CFLAGS] [--asflags ASFLAGS] [--ldflags LDFLAGS] [--smolrt SMOLRT] [--smolld SMOLLD]
                 [--verbose] [--keeptmp]
                 input [input ...] output
@@ -71,7 +70,6 @@ optional arguments:
                         entire binary as the Dyn table, so only enable this if you're sure this won't break things!
   --nasm NASM           which nasm binary to use
   --cc CC               which cc binary to use (MUST BE GCC!)
-  --scanelf SCANELF     which scanelf binary to use
   --readelf READELF     which readelf binary to use
   --cflags CFLAGS       Flags to pass to the C compiler for the relinking step
   --asflags ASFLAGS     Flags to pass to the assembler when creating the ELF header and runtime startup code

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Shoddy minsize-oriented linker
 
-PoC by Shiz, bugfixing and 64-bit version by PoroCYon.
+PoC by Shiz, bugfixing, 64-bit version and maintenance by PoroCYon,
+enhancements and bugfixes by blackle.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -18,15 +18,13 @@ PoC by Shiz, bugfixing and 64-bit version by PoroCYon.
 the smol startup/symbol resolving code will jump to an undefined location.
 
 ```sh
-./smold.py --use_interp --align_stack [--opts...] -lfoo -lbar input.o... output.elf
+./smold.py -fuse-interp -falign-stack [--opts...] -lfoo -lbar input.o... output.elf
 ```
 
 ```
-usage: smold.py [-h] [-m TARGET] [-l LIB] [-L DIR] [-s] [-n] [-d] [-fuse-interp] [-falign-stack] [-fuse-nx]
-                [-fuse-dnload-loader] [-fskip-zero-value] [-fuse-dt-debug] [-fuse-dl-fini] [-fskip-entries]
-                [-fno-start-arg] [-funsafe-dynamic] [--nasm NASM] [--cc CC] [--readelf READELF]
-                [--cflags CFLAGS] [--asflags ASFLAGS] [--ldflags LDFLAGS] [--smolrt SMOLRT] [--smolld SMOLLD]
-                [--verbose] [--keeptmp]
+usage: smold.py [-h] [-m TARGET] [-l LIB] [-L DIR] [-s] [-n] [-d] [-fuse-interp] [-falign-stack] [-fuse-nx] [-fuse-dnload-loader] [-fskip-zero-value] [-fuse-dt-debug] [-fuse-dl-fini] [-fskip-entries] [-fno-start-arg] [-funsafe-dynamic]
+                [-fifunc-support] [-fifunc-strict-cconv] [--nasm NASM] [--cc CC] [--readelf READELF] [-Wc CFLAGS] [-Wa ASFLAGS] [-Wl LDFLAGS] [--smolrt SMOLRT] [--smolld SMOLLD] [--gen-rt-only] [--verbose] [--keeptmp]
+                [--debugout DEBUGOUT]
                 input [input ...] output
 
 positional arguments:
@@ -41,43 +39,39 @@ optional arguments:
                         libraries to link against
   -L DIR, --libdir DIR  directories to search libraries in
   -s, --hash16          Use 16-bit (BSD) hashes instead of 32-bit djb2 hashes. Implies -fuse-dnload-loader
-  -n, --nx              Use NX (i.e. don't use RWE pages). Costs the size of one phdr, plus some extra bytes on
-                        i386.
+  -n, --nx              Use NX (i.e. don't use RWE pages). Costs the size of one phdr, plus some extra bytes on i386.
   -d, --det             Make the order of imports deterministic (default: just use whatever binutils throws at us)
-  -fuse-interp          Include a program interpreter header (PT_INTERP). If not enabled, ld.so has to be invoked
-                        manually by the end user.
-  -falign-stack         Align the stack before running user code (_start). If not enabled, this has to be done
-                        manually. Costs 1 byte.
-  -fuse-nx              Don't use one big RWE segment, but use separate RW and RE ones. Use this to keep strict
-                        kernels (PaX/grsec) happy. Costs at least the size of one program header entry.
-  -fuse-dnload-loader   Use a dnload-style loader for resolving symbols, which doesn't depend on
-                        nonstandard/undocumented ELF and ld.so features, but is slightly larger. If not enabled, a
-                        smaller custom loader is used which assumes glibc.
-  -fskip-zero-value     Skip an ELF symbol with a zero address (a weak symbol) when parsing libraries at runtime.
-                        Try enabling this if you're experiencing sudden breakage. However, many libraries don't use
-                        weak symbols, so this doesn't often pose a problem. Costs ~5 bytes.
-  -fuse-dt-debug        Use the DT_DEBUG Dyn header to access the link_map, which doesn't depend on
-                        nonstandard/undocumented ELF and ld.so features. If not enabled, the link_map is accessed
-                        using data leaked to the entrypoint by ld.so, which assumes glibc. Costs ~10 bytes.
-  -fuse-dl-fini         Pass _dl_fini to the user entrypoint, which should be done to properly comply with all
-                        standards, but is very often not needed at all. Costs 2 bytes.
-  -fskip-entries        Skip the first two entries in the link map (resp. ld.so and the vDSO). Speeds up symbol
-                        resolving, but costs ~5 bytes.
-  -fno-start-arg        Don't pass a pointer to argc/argv/envp to the entrypoint using the standard calling
-                        convention. This means you need to read these yourself in assembly if you want to use them!
-                        (envp is a preprequisite for X11, because it needs $DISPLAY.) Frees 3 bytes.
-  -funsafe-dynamic      Don't end the ELF Dyn table with a DT_NULL entry. This might cause ld.so to interpret the
-                        entire binary as the Dyn table, so only enable this if you're sure this won't break things!
+  -fuse-interp          Include a program interpreter header (PT_INTERP). If not enabled, ld.so has to be invoked manually by the end user.
+  -falign-stack         Align the stack before running user code (_start). If not enabled, this has to be done manually. Costs 1 byte.
+  -fuse-nx              Don't use one big RWE segment, but use separate RW and RE ones. Use this to keep strict kernels (PaX/grsec) happy. Costs at least the size of one program header entry.
+  -fuse-dnload-loader   Use a dnload-style loader for resolving symbols, which doesn't depend on nonstandard/undocumented ELF and ld.so features, but is slightly larger. If not enabled, a smaller custom loader is used which assumes
+                        glibc.
+  -fskip-zero-value     Skip an ELF symbol with a zero address (a weak symbol) when parsing libraries at runtime. Try enabling this if you're experiencing sudden breakage. However, many libraries don't use weak symbols, so this doesn't
+                        often pose a problem. Costs ~5 bytes.
+  -fuse-dt-debug        Use the DT_DEBUG Dyn header to access the link_map, which doesn't depend on nonstandard/undocumented ELF and ld.so features. If not enabled, the link_map is accessed using data leaked to the entrypoint by ld.so,
+                        which assumes glibc. Costs ~10 bytes.
+  -fuse-dl-fini         Pass _dl_fini to the user entrypoint, which should be done to properly comply with all standards, but is very often not needed at all. Costs 2 bytes.
+  -fskip-entries        Skip the first two entries in the link map (resp. ld.so and the vDSO). Speeds up symbol resolving, but costs ~5 bytes.
+  -fno-start-arg        Don't pass a pointer to argc/argv/envp to the entrypoint using the standard calling convention. This means you need to read these yourself in assembly if you want to use them! (envp is a preprequisite for X11,
+                        because it needs $DISPLAY.) Frees 3 bytes.
+  -funsafe-dynamic      Don't end the ELF Dyn table with a DT_NULL entry. This might cause ld.so to interpret the entire binary as the Dyn table, so only enable this if you're sure this won't break things!
+  -fifunc-support       Support linking to IFUNCs. Probably needed on x86_64, but costs ~16 bytes. Ignored on platforms without IFUNC support.
+  -fifunc-strict-cconv  On i386, if -fifunc-support is specified, strictly follow the calling convention rules. Probably not needed, but you never know.
   --nasm NASM           which nasm binary to use
   --cc CC               which cc binary to use (MUST BE GCC!)
   --readelf READELF     which readelf binary to use
-  --cflags CFLAGS       Flags to pass to the C compiler for the relinking step
-  --asflags ASFLAGS     Flags to pass to the assembler when creating the ELF header and runtime startup code
-  --ldflags LDFLAGS     Flags to pass to the linker for the final linking step
+  -Wc CFLAGS, --cflags CFLAGS
+                        Flags to pass to the C compiler for the relinking step
+  -Wa ASFLAGS, --asflags ASFLAGS
+                        Flags to pass to the assembler when creating the ELF header and runtime startup code
+  -Wl LDFLAGS, --ldflags LDFLAGS
+                        Flags to pass to the linker for the final linking step
   --smolrt SMOLRT       Directory containing the smol runtime sources
   --smolld SMOLLD       Directory containing the smol linker scripts
+  --gen-rt-only         Only generate the headers/runtime assembly source file, instead of doing a full link. (I.e. fall back to pre-release behavior.)
   --verbose             Be verbose about what happens and which subcommands are invoked
   --keeptmp             Keep temp files (only useful for debugging)
+  --debugout DEBUGOUT   Write out an additional, unrunnable debug ELF file with symbol information. (Useful for debugging with gdb, cannot be ran due to broken relocations.)
 ```
 
 A minimal crt (and `_start` funcion) are provided in case you want to use `main`.
@@ -88,6 +82,19 @@ A minimal crt (and `_start` funcion) are provided in case you want to use `main`
 imported by a `smol`-ified binary. This can thus be used to detect user mistakes
 during dynamic linking. (Think of it as an equivalent of `ldd`, except that it
 also checks whether the imported functions are present as well.)
+
+```
+usage: smoldd.py [-h] [--cc CC] [--readelf READELF] [--map MAP] input
+
+positional arguments:
+  input              input file
+
+optional arguments:
+  -h, --help         show this help message and exit
+  --cc CC            C compiler binary
+  --readelf READELF  readelf binary
+  --map MAP          Get the address of the symbol hash table from the linker map output instead of attempting to parse the binary.
+```
 
 ## Internal workings
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ enhancements and bugfixes by blackle.
 `.text.startup._start`! Otherwise, the linker script will fail silently, and
 the smol startup/symbol resolving code will jump to an undefined location.
 
-***NOTE***: C++ exceptions, RTTI, global *external* variables, global
-constructors and destructors (the ELF `.ctors`/`.dtors`/
+***NOTE***: C++ exceptions, RTTI, global *external* variables, thread-local
+storage, global constructors and destructors (the ELF `.ctors`/`.dtors`/
 `attribute((con-/destructor))` things, not the C++ language constructs), ...
 aren't supported yet, and probably won't be anytime soon.
 

--- a/ld/link.ld
+++ b/ld/link.ld
@@ -1,10 +1,19 @@
-OUTPUT_FORMAT(binary)
+OUTPUT_FORMAT("elf64-x86-64", "elf64-x86-64", "elf64-x86-64")
+OUTPUT_ARCH(i386:x86-64)
+ENTRY(_smol_start)
+SEARCH_DIR("/usr/x86_64-pc-linux-gnu/lib64"); SEARCH_DIR("/usr/lib"); SEARCH_DIR("/usr/local/lib"); SEARCH_DIR("/usr/x86_64-pc-linux-gnu/lib");
+/*OUTPUT_FORMAT(binary)*/
+
+PHDRS {
+	rodttxt PT_LOAD FLAGS(5); /* r-x */
+	rwdt    PT_LOAD FLAGS(6); /* rw- */
+}
 
 SECTIONS {
   . = 0x10000;
   _smol_origin = .;
 
-  .header : { KEEP(*(.header)) }
+  .header : { KEEP(*(.header)) } :rodttxt
 
   _smol_text_start = .;
   _smol_text_off = _smol_text_start - _smol_origin;
@@ -15,7 +24,7 @@ SECTIONS {
      KEEP(*(.text.startup.smol))
      KEEP(*(.text.startup._start))
      *(.text .text.*)
-  }
+  } :rodttxt
   _smol_text_end = .;
   _smol_text_size = _smol_text_end - _smol_text_start;
 
@@ -26,10 +35,10 @@ SECTIONS {
   .data : {
      KEEP(*(.data.smolgot))
      *(.data .data.* .tdata .tdata.*)
-  }
+  } :rwdt
 
-  .dynamic : { *(.dynamic) } :all :dyn
-  .dynstuff : { *(.symtab .strtab .shstrtab .rel.text .got.plt .gnu.linkonce.* .plt .plt.got .interp) } :all
+  .dynamic : { *(.dynamic) } :rodttxt :dyn
+  .dynstuff : { *(.symtab .strtab .shstrtab .rel.text .got.plt .gnu.linkonce.* .plt .plt.got .interp) } :rodttxt
   _smol_data_end = .;
   _smol_data_size = _smol_data_end - _smol_data_start;
 
@@ -39,7 +48,7 @@ SECTIONS {
   _smol_bss_off = _smol_bss_start - _smol_origin;
   .bss : {
       *(.bss .bss.* .tbss .tbss.* .sbss .sbss.*)
-  }
+  } :rwdt
   _smol_bss_end = .;
   _smol_bss_size = _smol_bss_end - _smol_bss_start;
 

--- a/ld/link_common.ld
+++ b/ld/link_common.ld
@@ -2,8 +2,10 @@
 ENTRY(_smol_start)
 
 PHDRS {
-	rodttxt PT_LOAD FLAGS(5); /* r-x */
-	rwdt    PT_LOAD FLAGS(6); /* rw- */
+	dyn     PT_DYNAMIC FLAGS(0); /* --- */
+	interp  PT_INTERP  FLAGS(0); /* --- */
+	rodttxt PT_LOAD    FLAGS(5); /* r-x */
+	rwdt    PT_LOAD    FLAGS(6); /* rw- */
 }
 
 SECTIONS {
@@ -11,6 +13,8 @@ SECTIONS {
   _smol_origin = .;
 
   .header : { KEEP(*(.header)) } :rodttxt
+  .dynamic : { *(.dynamic .rodata.dynamic) } :dyn :rodttxt
+  .interp : { *(.interp .rodata.interp) } :interp /*:rodttxt*/
 
   _smol_text_start = .;
   _smol_text_off = _smol_text_start - _smol_origin;
@@ -34,8 +38,7 @@ SECTIONS {
      *(.data .data.* .tdata .tdata.*)
   } :rwdt
 
-  .dynamic : { *(.dynamic) } :rodttxt :dyn
-  .dynstuff : { *(.symtab .strtab .shstrtab .rel.text .got.plt .gnu.linkonce.* .plt .plt.got .interp) } :rodttxt
+  .dynstuff : { *(.symtab .strtab .shstrtab .rel.text .got.plt .gnu.linkonce.* .plt .plt.got) } /*:dyn*/ :rodttxt
   _smol_data_end = .;
   _smol_data_size = _smol_data_end - _smol_data_start;
 

--- a/ld/link_common.ld
+++ b/ld/link_common.ld
@@ -54,6 +54,48 @@ SECTIONS {
 
   _smol_dataandbss_size = _smol_bss_end - _smol_data_start;
 
+  /* Stabs debugging sections.  */
+  .stab          0 : { *(.stab) }
+  .stabstr       0 : { *(.stabstr) }
+  .stab.excl     0 : { *(.stab.excl) }
+  .stab.exclstr  0 : { *(.stab.exclstr) }
+  .stab.index    0 : { *(.stab.index) }
+  .stab.indexstr 0 : { *(.stab.indexstr) }
+  /*.comment       0 : { *(.comment) }*/
+  /*.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }*/
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* SGI/MIPS DWARF 2 extensions */
+  .debug_weaknames 0 : { *(.debug_weaknames) }
+  .debug_funcnames 0 : { *(.debug_funcnames) }
+  .debug_typenames 0 : { *(.debug_typenames) }
+  .debug_varnames  0 : { *(.debug_varnames) }
+  /* DWARF 3 */
+  .debug_pubtypes 0 : { *(.debug_pubtypes) }
+  .debug_ranges   0 : { *(.debug_ranges) }
+  /* DWARF Extension.  */
+  .debug_macro    0 : { *(.debug_macro) }
+  .debug_addr     0 : { *(.debug_addr) }
+  /*.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }*/
+
   /DISCARD/ : {
      *(.*)
   }

--- a/ld/link_common.ld
+++ b/ld/link_common.ld
@@ -1,8 +1,5 @@
-OUTPUT_FORMAT("elf64-x86-64", "elf64-x86-64", "elf64-x86-64")
-OUTPUT_ARCH(i386:x86-64)
-ENTRY(_smol_start)
-SEARCH_DIR("/usr/x86_64-pc-linux-gnu/lib64"); SEARCH_DIR("/usr/lib"); SEARCH_DIR("/usr/local/lib"); SEARCH_DIR("/usr/x86_64-pc-linux-gnu/lib");
 /*OUTPUT_FORMAT(binary)*/
+ENTRY(_smol_start)
 
 PHDRS {
 	rodttxt PT_LOAD FLAGS(5); /* r-x */

--- a/ld/link_common.ld
+++ b/ld/link_common.ld
@@ -54,6 +54,8 @@ SECTIONS {
 
   _smol_dataandbss_size = _smol_bss_end - _smol_data_start;
 
+  _smol_total_memsize = . - _smol_origin;
+
   /* Stabs debugging sections.  */
   .stab          0 : { *(.stab) }
   .stabstr       0 : { *(.stabstr) }
@@ -99,7 +101,5 @@ SECTIONS {
   /DISCARD/ : {
      *(.*)
   }
-
-  _smol_total_memsize = . - _smol_origin;
 }
 

--- a/ld/link_i386.ld
+++ b/ld/link_i386.ld
@@ -1,0 +1,6 @@
+OUTPUT_FORMAT("elf32-i386")
+OUTPUT_ARCH(i386)
+SEARCH_DIR("/usr/i386-pc-linux-gnu/lib32"); SEARCH_DIR("/usr/x86_64-pc-linux-gnu/lib32"); SEARCH_DIR("/usr/lib"); SEARCH_DIR("/usr/local/lib"); SEARCH_DIR("/usr/i386-pc-linux-gnu/lib");
+
+INCLUDE "link_common.ld"
+

--- a/ld/link_x86_64.ld
+++ b/ld/link_x86_64.ld
@@ -1,0 +1,6 @@
+OUTPUT_FORMAT("elf64-x86-64")
+OUTPUT_ARCH(i386:x86-64)
+SEARCH_DIR("/usr/x86_64-pc-linux-gnu/lib64"); SEARCH_DIR("/usr/lib"); SEARCH_DIR("/usr/local/lib"); SEARCH_DIR("/usr/x86_64-pc-linux-gnu/lib");
+
+INCLUDE "link_common.ld"
+

--- a/rt/elf.inc
+++ b/rt/elf.inc
@@ -34,17 +34,22 @@
 %define DT_SYMTAB ( 6)
 %define DT_DEBUG  (21)
 
-%define ST_NAME_OFF  ( 0)
+%define ST_NAME_OFF       ( 0)
+%define ST_INFO__STT_MASK (15)
+%define STT_GNU_IFUNC     (10)
+
 ;  ,---- not 16? ; what's this comment??!
 ; v
 %if __BITS__ == 32
 %define D_UN_PTR_OFF         ( 4)
 %define ST_VALUE_OFF         ( 4)
+%define ST_INFO_OFF          (12)
 %define SYMTAB_SIZE          (16)
 %define ELF_DYN_SZ           ( 8)
 %else
 %define D_UN_PTR_OFF         ( 8)
 %define ST_VALUE_OFF         ( 8)
+%define ST_INFO_OFF          ( 4)
 %define SYMTAB_SIZE          (24)
 %define ELF_DYN_SZ           (16)
 %endif

--- a/rt/loader32.asm
+++ b/rt/loader32.asm
@@ -2,6 +2,11 @@
 
 %include "rtld.inc"
 
+%ifndef HASH_END_TYP
+%warning "W: HASH_END_TYP not defined, falling back to 16-bit!"
+%define HASH_END_TYP word
+%endif
+
 %define R10_BIAS (0x178)
 
 %ifdef ELF_TYPE
@@ -186,7 +191,7 @@ _smol_start:
 %ifdef USE_JMP_BYTES
             inc edi ; skip 0xE9 (jmp) offset
 %endif
-            cmp word [edi], 0
+            cmp HASH_END_TYP [edi], 0
             jne short .next_hash
 
 ; if USE_DNLOAD_LOADER
@@ -300,7 +305,7 @@ repne scasd
 %ifdef USE_JMP_BYTES
                 inc edi
 %endif
-                cmp word [edi], 0
+                cmp HASH_END_TYP [edi], 0
                 jne short .next_hash
 
        pop eax ; get rid of leftover ecx on stack

--- a/rt/loader32.asm
+++ b/rt/loader32.asm
@@ -107,8 +107,7 @@ _smol_start:
 
                 ; source in eax, result in eax
 %ifdef USE_CRC32C_HASH
-           push -1
-            pop eax
+           xor ecx, ecx
 %else
     %ifndef USE_HASH16
            push ebx

--- a/rt/loader32.asm
+++ b/rt/loader32.asm
@@ -168,7 +168,16 @@ _smol_start:
             cmp al, STT_GNU_IFUNC
             jne short .no_ifunc
           ;int3
+%ifdef IFUNC_CORRECT_CCONV
+                ; call destroys stuff, but we only need to preserve edi
+                ; for our purposes anyway. we do need one push to align the
+                ; stack to 16 bytes
+           push edi
            call ecx
+            pop edi
+%else
+           call ecx
+%endif
              db 0x3c ; cmp al, <next byte == xchg ecx,eax> --> jump over next insn
         .no_ifunc:
            xchg ecx, eax
@@ -273,7 +282,16 @@ repne scasd
                 cmp al, STT_GNU_IFUNC
                 jne short .no_ifunc
               ;int3
+%ifdef IFUNC_CORRECT_CCONV
+                    ; call destroys stuff, but we only need to preserve edi
+                    ; for our purposes anyway. we do need one push to align the
+                    ; stack to 16 bytes
+               push edi
                call ecx
+                pop edi
+%else
+               call ecx
+%endif
                  db 0x3c ; cmp al, <next byte == xchg ecx,eax> --> jump over next insn
             .no_ifunc:
                xchg ecx, eax

--- a/rt/loader32.asm
+++ b/rt/loader32.asm
@@ -107,7 +107,7 @@ _smol_start:
 
                 ; source in eax, result in eax
 %ifdef USE_CRC32C_HASH
-           xor ecx, ecx
+            xor eax, eax
 %else
     %ifndef USE_HASH16
            push ebx
@@ -125,6 +125,7 @@ _smol_start:
               lodsb
                  or al, al
                xchg eax, ecx
+              ;jcxz .breakhash
                  jz short .breakhash
 
 %ifdef USE_CRC32C_HASH
@@ -144,8 +145,10 @@ _smol_start:
                 jmp short .nexthashiter
 
         .breakhash:
+%ifndef USE_CRC32C_HASH
 %ifndef USE_HASH16
             pop ebx
+%endif
 %endif
             pop ecx
 ;%ifndef USE_HASH16

--- a/rt/loader32.asm
+++ b/rt/loader32.asm
@@ -51,7 +51,9 @@ _smol_start:
    push _symbols
 %endif
 
-;.loopme: jmp short .loopme
+%ifdef HANG_ON_STARTUP
+.loopme: jmp short .loopme
+%endif
 %ifdef USE_DNLOAD_LOADER
    push eax
     pop ebp

--- a/rt/loader64.asm
+++ b/rt/loader64.asm
@@ -55,7 +55,9 @@ _smol_start:
     pop r11
     pop rdi
 
-;.loopme: jmp short .loopme ; debugging
+%ifdef HANG_ON_STARTUP
+.loopme: jmp short .loopme ; debugging
+%endif
     .next_hash:
         mov r14d, dword [rdi]
             ; assume it's nonzero
@@ -240,7 +242,9 @@ repne scasd ; technically, scasq should be used, but meh. this is 1 byte smaller
     pop r11
     pop rdi
 
-;.loopme: jmp short .loopme ; debugging
+%ifdef HANG_ON_STARTUP
+.loopme: jmp short .loopme ; debugging
+%endif
     .next_hash:
         mov r14d, dword [rdi]
             ; assume we need at least one function

--- a/rt/loader64.asm
+++ b/rt/loader64.asm
@@ -112,8 +112,7 @@ _smol_start:
             pop rbx
 %else
                 ; crc32
-           push -1
-            pop rcx
+           xor ecx, ecx
 %endif
         .nexthashiter:
 %ifndef USE_CRC32C_HASH

--- a/rt/loader64.asm
+++ b/rt/loader64.asm
@@ -1,5 +1,10 @@
 ; vim: set ft=nasm:
 
+%ifndef HASH_END_TYP
+%warning "W: HASH_END_TYP not defined, falling back to 16-bit!"
+%define HASH_END_TYP word
+%endif
+
 ;%define R10_BIAS (0x2B4)
 %define R10_BIAS (0x2B4+0x40)
 
@@ -153,7 +158,7 @@ _smol_start:
 %endif
 %endif
           stosq
-            cmp word [rdi], 0
+            cmp HASH_END_TYP [rdi], 0
 %ifdef IFUNC_SUPPORT
 %ifdef SKIP_ZERO_VALUE
             jne .next_hash;short .next_hash
@@ -311,7 +316,7 @@ repne scasd ; technically, scasq should be used, but meh. this is 1 byte smaller
 ; IFUNC_SUPPORT
 %endif
           stosq ; *phash = finaladdr
-            cmp word [rdi], 0
+            cmp HASH_END_TYP [rdi], 0
             jne short .next_hash
             ; } while (1)
 ;       jmp short .next_hash

--- a/rt/loader64.asm
+++ b/rt/loader64.asm
@@ -1,4 +1,4 @@
-; vim: set ft=nasm:
+; vim: set ft=nasm et:
 
 %ifndef HASH_END_TYP
 %warning "W: HASH_END_TYP not defined, falling back to 16-bit!"
@@ -101,6 +101,8 @@ _smol_start:
             mov esi, dword [rdx + ST_NAME_OFF]
             add rsi, r8;9
 
+%ifndef USE_CRC32C_HASH
+                ; djb2
             xor ecx, ecx
            push 33
            push 5381
@@ -108,22 +110,45 @@ _smol_start:
 ;           pop rcx
             pop rax
             pop rbx
+%else
+                ; crc32
+           push -1
+            pop rcx
+%endif
         .nexthashiter:
+%ifndef USE_CRC32C_HASH
+                    ; djb2
                     ; TODO: optimize register usage a bit more
                xchg eax, ecx
+%endif
               lodsb
                  or al, al
+%ifndef USE_CRC32C_HASH
+                    ; djb2
                xchg eax, ecx
+%endif
                  jz short .breakhash
 
+%ifndef USE_CRC32C_HASH
+                    ; djb2
                push rdx
                 mul ebx
                 pop rdx
                 add eax, ecx
+%else
+                    ; crc32c
+              crc32 ecx, al
+%endif
                 jmp short .nexthashiter
         .breakhash:
-
+%ifdef USE_CRC32C_HASH
+                ; crc32c
+            cmp r14d, ecx
+%else
+                ; djb2
             cmp r14d, eax
+
+%endif
              je short .hasheq
 
             add rdx, SYMTAB_SIZE
@@ -144,7 +169,7 @@ _smol_start:
 %ifdef IFUNC_SUPPORT
             and cl, ST_INFO__STT_MASK
             cmp cl, STT_GNU_IFUNC
-%ifdef SKIP_ZERO_VALUE
+    %ifdef SKIP_ZERO_VALUE
             jne short .no_ifunc2
            push rdi
            push r11
@@ -152,25 +177,25 @@ _smol_start:
             pop r11
             pop rdi
         .no_ifunc2:
-%else           ; !SKIP_ZERO_VALUE
+    %else       ; !SKIP_ZERO_VALUE
              je short .ifunc
         .no_ifunc:
-%endif
+    %endif
 %endif
           stosq
             cmp HASH_END_TYP [rdi], 0
 %ifdef IFUNC_SUPPORT
-%ifdef SKIP_ZERO_VALUE
+    %ifdef SKIP_ZERO_VALUE
             jne .next_hash;short .next_hash
-%else           ; IFUNC_SUPPORT && !SKIP_ZERO_VALUE
+    %else       ; IFUNC_SUPPORT && !SKIP_ZERO_VALUE
             jne short .next_hash
-%endif
+    %endif
 %else           ; !IFUNC_SUPPORT
             jne short .next_hash
 %endif
 
 %ifdef IFUNC_SUPPORT
-%ifndef SKIP_ZERO_VALUE
+    %ifndef SKIP_ZERO_VALUE
             jmp short .break_loop
         .ifunc:
          ;;int3 ; in this call, we lose rax rcx rdx rsi rdi r8 r9 r10 r11
@@ -194,7 +219,7 @@ _smol_start:
            ;pop rcx
             jmp short .no_ifunc
         .break_loop:
-%endif
+    %endif
 %endif
 
 ; if USE_DNLOAD_LOADER

--- a/smol/cnl.py
+++ b/smol/cnl.py
@@ -31,7 +31,7 @@ def nasm_assemble_elfhdr(verbose, nasm_bin, arch, rtdir, intbl, output, asflags)
 def ld_link_final(verbose, cc_bin, arch, lddir, inobjs, output, ldflags, debug):
     archflag = '-m64' if arch == "x86_64" else '-m32'
 
-    args = [cc_bin, archflag, '-L', lddir, '-T', lddir+('/link_%s.ld'%arch), '-no-pie']
+    args = [cc_bin, archflag, '-L', lddir, '-T', '%s/link_%s.ld'%(lddir,arch), '-no-pie']
     if not debug:
         args.append('-Wl,--oformat=binary')
         #args = [*args, '-T', lddir+'/link.ld', '-Wl,--oformat=binary']

--- a/smol/cnl.py
+++ b/smol/cnl.py
@@ -28,12 +28,14 @@ def nasm_assemble_elfhdr(verbose, nasm_bin, arch, rtdir, intbl, output, asflags)
     if verbose: eprintf("nasm: %s" % repr(args))
     subprocess.check_call(args, stdout=subprocess.DEVNULL)
 
-def ld_link_final(verbose, cc_bin, arch, lddir, inobjs, output, ldflags):
+def ld_link_final(verbose, cc_bin, arch, lddir, inobjs, output, ldflags, debug):
     archflag = '-m64' if arch == "x86_64" else '-m32'
 
-    args = [cc_bin, archflag, '-T', lddir+'/link.ld', \
-            '-Wl,--oformat=binary', '-nostartfiles', '-nostdlib', \
-            '-o', output] + inobjs + ldflags
+    args = [cc_bin, archflag, '-T', lddir+'/link.ld', '-no-pie']
+    if not debug:
+        args.append('-Wl,--oformat=binary')
+        #args = [*args, '-T', lddir+'/link.ld', '-Wl,--oformat=binary']
+    args += ['-nostartfiles', '-nostdlib', '-o', output, *inobjs, *ldflags]
 
     if verbose: eprintf("ld: %s" % repr(args))
     subprocess.check_call(args, stdout=subprocess.DEVNULL)

--- a/smol/cnl.py
+++ b/smol/cnl.py
@@ -31,7 +31,7 @@ def nasm_assemble_elfhdr(verbose, nasm_bin, arch, rtdir, intbl, output, asflags)
 def ld_link_final(verbose, cc_bin, arch, lddir, inobjs, output, ldflags, debug):
     archflag = '-m64' if arch == "x86_64" else '-m32'
 
-    args = [cc_bin, archflag, '-T', lddir+'/link.ld', '-no-pie']
+    args = [cc_bin, archflag, '-L', lddir, '-T', lddir+('/link_%s.ld'%arch), '-no-pie']
     if not debug:
         args.append('-Wl,--oformat=binary')
         #args = [*args, '-T', lddir+'/link.ld', '-Wl,--oformat=binary']

--- a/smol/emit.py
+++ b/smol/emit.py
@@ -41,9 +41,8 @@ def sort_imports(libraries, hashfn):
     #if sys.version_info < (3, 6): return OrderedDict(ll)
     #else: return dict(ll)
 
-    ll = libraries.items()
-    for k, v in ll:
-        libraries[k] = sorted(v, key=lambda sr: hashfn(sr[0]))
+    for k, v in libraries.items():
+        libraries[k] = OrderedDict(sorted(v.items(), key=lambda sr: hashfn(sr[0])))
 
     return libraries
 

--- a/smol/emit.py
+++ b/smol/emit.py
@@ -10,13 +10,16 @@ def get_min_check_width(libraries, hashfn):
     minv = 8 # can't go lower
     for k, v in libraries.items():
         for sym in v:
-            hv = hashfn(sym[0]) # sym == (name, reloc)
+            hv = hashfn(sym)
+            #eprintf("hash: 0x%08x of %s"%(hv,sym))
             if (hv & 0xffffffff) == 0:
                 # this should (hopefully) NEVER happen
-                error("Aiee, all-zero hash for sym '%s'!" % sym)
+                error("E: Aiee, all-zero hash for sym '%s'!" % sym)
             elif (hv & 0xFFFF) == 0:
+                #eprintf("32-bit hash")
                 minv = max(minv, 32) # need at least 32 bits
             elif (hv & 0xFF) == 0:
+                #eprintf("16-bit hash")
                 minv = max(minv, 16) # need at least 16 bits
 
     return minv

--- a/smol/hackyelf.py
+++ b/smol/hackyelf.py
@@ -8,6 +8,7 @@
 from struct import unpack
 from typing import *
 
+
 ELFCLASS32 = 1
 ELFCLASS64 = 2
 
@@ -24,6 +25,30 @@ DT_NEEDED = 1
 DT_STRTAB = 5
 DT_SYMTAB = 6
 
+SHT_NULL     =  0
+SHT_PROGBITS =  1
+SHT_SYMTAB   =  2
+SHT_STRTAB   =  3
+SHT_DYNSYM   = 11
+
+STB_LOCAL  = 0
+STB_GLOBAL = 1
+STB_WEAK   = 2
+
+STT_NOTYPE = 0
+STT_OBJECT = 1
+STT_FUNC   = 2
+STT_SECTION= 3
+STT_FILE   = 4
+STT_COMMON = 5
+STT_TLS    = 6
+STT_GNU_IFUNC = 10
+
+STV_DEFAULT   = 0
+STV_INTERNAL  = 1
+STV_HIDDEN    = 2
+STV_PROTECTED = 3
+
 class Phdr(NamedTuple):
     ptype: int
     off  : int
@@ -38,6 +63,27 @@ class Dyn(NamedTuple):
     tag: int
     val: int
 
+class Shdr(NamedTuple):
+    name: Union[int, str]
+    type: int
+    flags: int
+    addr: int
+    offset: int
+    size: int
+    link: int
+    info: int
+    addralign: int
+    entsize: int
+
+class Sym(NamedTuple):
+    name: str
+    value: int
+    size: int
+    type: int
+    binding: int
+    visibility: int
+    shndx: int
+
 class ELF(NamedTuple):
     data  : bytes
     ident : bytes
@@ -46,7 +92,17 @@ class ELF(NamedTuple):
     entry : int
     phdrs : Sequence[Phdr]
     dyn   : Sequence[Dyn]
+    shdrs : Sequence[Shdr]
+    symtab: Sequence[Sym]
+    dynsym: Sequence[Sym]
     is32bit: bool
+
+def readstr(data: bytes, off: int) -> str:
+    strb = bytearray()
+    while data[off] != 0 and off < len(data):
+        strb.append(data[off])
+        off = off + 1
+    return strb.decode('utf-8')
 
 # yeah, there's some code duplication here
 # idgaf
@@ -74,6 +130,46 @@ def parse_dyn32(data: bytes, dynp: Phdr) -> Dyn:
 
     return ds
 
+def parse_shdr32(data: bytes, shoff: int, shentsz: int, shnum: int,
+                 shstrndx: int) -> Sequence[Shdr]:
+    if shnum*shentsz+shoff > len(data) or shentsz==0 or shnum==0 or shoff==0:
+        print("snum*shentsz+shoff",shnum*shentsz+shoff)
+        print("len(data)",len(data))
+        print("shentsz",shentsz)
+        print("shnum",shnum)
+        print("shoff",shoff)
+        return []
+
+    ss = []
+    for off in range(shoff, shoff+shentsz*shnum, shentsz):
+        noff, typ, flags, addr, off, size, link, info, align, entsz = \
+            unpack('<IIIIIIIIII', data[off:off+10*4])
+        s = Shdr(noff, typ, flags, addr, off, size, link, info, align, entsz)
+        ss.append(s)
+
+    if shstrndx < shnum:
+        shstr = ss[shstrndx]
+        for i in range(len(ss)):
+            sname = readstr(data, shstr.offset + ss[i].name) \
+                if ss[i].name < shstr.size else None
+            ss[i] = Shdr(sname, ss[i].type, ss[i].flags, ss[i].addr,
+                         ss[i].offset, ss[i].size, ss[i].link, ss[i].info,
+                         ss[i].addralign, ss[i].entsize)
+
+    return ss
+
+def parse_sym32(data: bytes, sym: Shdr, strt: Shdr) -> Sequence[Sym]:
+    ss = []
+    for off in range(sym.offset, sym.offset+sym.size, sym.entsize):
+        noff, val, sz, info, other, shndx = \
+            unpack('<IIIBBH', data[off:off+3*4+2+2])
+
+        sn = readstr(data, strt.offset + noff) \
+            if noff < strt.size else None
+        s = Sym(sn, val, sz, (info & 15), (info >> 4), other, shndx)
+        ss.append(s)
+    return sorted(ss, key=lambda x:x.value)
+
 def parse_32(data: bytes) -> ELF:
     ident  = data[:16]
     eclass = data[4]
@@ -81,8 +177,12 @@ def parse_32(data: bytes) -> ELF:
     entry  = unpack('<I', data[24:24+4])[0]
 
     phoff   = unpack('<I', data[28:28+4])[0]
+    shoff   = unpack('<I', data[32:32+4])[0]
     phentsz = unpack('<H', data[42:42+2])[0]
     phnum   = unpack('<H', data[44:44+2])[0]
+    shentsz = unpack('<H', data[46:46+2])[0]
+    shnum   = unpack('<H', data[48:48+2])[0]
+    shstrndx= unpack('<H', data[50:50+2])[0]
 
     phdrs = parse_phdr32(data, phoff, phentsz, phnum)
     dyn   = None
@@ -92,12 +192,37 @@ def parse_32(data: bytes) -> ELF:
             dyn = parse_dyn32(data, p)
             break
 
-    return ELF(data, ident, eclass, mach, entry, phdrs, dyn, True)
+    shdrs = parse_shdr32(data, shoff, shentsz, shnum, shstrndx)
+    #print("shdrs",shdrs)
+
+    symtabsh = [s for s in shdrs if s.type == SHT_SYMTAB and s.name == ".symtab"]
+    strtabsh = [s for s in shdrs if s.type == SHT_STRTAB and s.name == ".strtab"]
+    dynsymsh = [s for s in shdrs if s.type == SHT_SYMTAB and s.name == ".dynsym"]
+    dynstrsh = [s for s in shdrs if s.type == SHT_STRTAB and s.name == ".dynstr"]
+
+    #print("symtab",symtabsh)
+    #print("strtab",strtabsh)
+
+    assert len(symtabsh) < 2
+    assert len(strtabsh) < 2
+    assert len(dynsymsh) < 2
+    assert len(dynstrsh) < 2
+
+    symtab, dynsym = None, None
+    if len(symtabsh) and len(strtabsh):
+        symtab = parse_sym32(data, symtabsh[0], strtabsh[0]) \
+            if len(shdrs) > 0 else []
+    if len(dynsymsh) and len(dynstrsh):
+        dynsym = parse_sym32(data, symtabsh[0], strtabsh[0]) \
+            if len(shdrs) > 0 else []
+
+    return ELF(data, ident, eclass, mach, entry, phdrs, dyn, shdrs,
+               symtab, dynsym, True)
 
 def parse_phdr64(data: bytes, phoff:int, phentsz:int, phnum:int) -> Sequence[Phdr]:
     ps = []
     for off in range(phoff, phoff+phentsz*phnum, phentsz):
-        # TODO
+        # TODO # what is TODO exactly??
         ptype, flags, off, vaddr, paddr, filesz, memsz, align = \
             unpack('<IIQQQQQQ', data[off:off+2*4+6*8])
         p = Phdr(ptype, off, vaddr, paddr, filesz, memsz, flags, align)
@@ -118,6 +243,41 @@ def parse_dyn64(data: bytes, dynp: Phdr) -> Dyn:
 
     return ds
 
+def parse_shdr64(data: bytes, shoff: int, shentsz: int, shnum: int,
+                 shstrndx: int) -> Sequence[Shdr]:
+    if shnum*shentsz+shoff >= len(data) or shentsz==0 or shnum==0 or shoff==0:
+        return []
+
+    ss = []
+    for off in range(shoff, shoff+shentsz*shnum, shentsz):
+        noff, typ, flags, addr, off, size, link, info, align, entsz = \
+            unpack('<IIQQQQIIQQ', data[off:off+4*4+6*8])
+        s = Shdr(noff, typ, flags, addr, off, size, link, info, align, entsz)
+        ss.append(s)
+
+    if shstrndx < shnum:
+        shstr = ss[shstrndx]
+        for i in range(len(ss)):
+            sname = readstr(data, shstr.offset + ss[i].name) \
+                if ss[i].name < shstr.size else None
+            ss[i] = Shdr(sname, ss[i].type, ss[i].flags, ss[i].addr,
+                         ss[i].offset, ss[i].size, ss[i].link, ss[i].info,
+                         ss[i].addralign, ss[i].entsize)
+
+    return ss
+
+def parse_sym64(data: bytes, sym: Shdr, strt: Shdr) -> Sequence[Sym]:
+    ss = []
+    for off in range(sym.offset, sym.offset+sym.size, sym.entsize):
+        noff, info, other, shndx, value, sz = \
+            unpack('<IBBHQQ', data[off:off+4+2+2+8*2])
+
+        sn = readstr(data, strt.offset + noff) \
+            if noff < strt.size else None
+        s = Sym(sn, val, sz, (info & 15), (info >> 4), other, shndx)
+        ss.append(s)
+    return sorted(ss, key=lambda x:x.value)
+
 def parse_64(data: bytes) -> ELF:
     ident  = data[:16]
     eclass = data[4]
@@ -125,8 +285,12 @@ def parse_64(data: bytes) -> ELF:
     entry  = unpack('<Q', data[24:24+8])[0]
 
     phoff   = unpack('<Q', data[32:32+8])[0]
+    shoff   = unpack('<Q', data[40:40+8])[0]
     phentsz = unpack('<H', data[54:54+2])[0]
     phnum   = unpack('<H', data[56:56+2])[0]
+    shentsz = unpack('<H', data[58:58+2])[0]
+    shnum   = unpack('<H', data[60:60+2])[0]
+    shstrndx= unpack('<H', data[62:62+2])[0]
 
     phdrs = parse_phdr64(data, phoff, phentsz, phnum)
     dyn   = None
@@ -136,7 +300,28 @@ def parse_64(data: bytes) -> ELF:
             dyn = parse_dyn64(data, p)
             break
 
-    return ELF(data, ident, eclass, mach, entry, phdrs, dyn, False)
+    shdrs = parse_shdr64(data, shoff, shentsz, shnum, shstrndx)
+
+    symtabsh = [s for s in shdrs if s.type == SHT_SYMTAB and s.name == ".symtab"]
+    strtabsh = [s for s in shdrs if s.type == SHT_STRTAB and s.name == ".strtab"]
+    dynsymsh = [s for s in shdrs if s.type == SHT_SYMTAB and s.name == ".dynsym"]
+    dynstrsh = [s for s in shdrs if s.type == SHT_STRTAB and s.name == ".dynstr"]
+
+    assert len(symtabsh) < 2
+    assert len(strtabsh) < 2
+    assert len(dynsymsh) < 2
+    assert len(dynstrsh) < 2
+
+    symtab, dynsym = None, None
+    if len(symtabsh) and len(strtabsh):
+        symtab = parse_sym64(data, symtabsh[0], strtabsh[0]) \
+            if len(shdrs) > 0 else []
+    if len(dynsymsh) and len(dynstrsh):
+        dynsym = parse_sym64(data, symtabsh[0], strtabsh[0]) \
+            if len(shdrs) > 0 else []
+
+    return ELF(data, ident, eclass, mach, entry, phdrs, dyn, shdrs,
+               symtab, dynsym, False)
 
 def parse(data: bytes) -> ELF:
     assert data[:4] == b'\x7FELF', "Not a valid ELF file" # good enough

--- a/smol/linkmap.py
+++ b/smol/linkmap.py
@@ -82,7 +82,7 @@ def parse_mmap(ls: Sequence[str]) -> Sequence[MMap]:
         if len(symn) > 0:
             rrr.append(MMap(section, addr, symn, curfile))
 
-    return rrr
+    return sorted(rrr, key=lambda m: m.org)
 
 def parse(s: str) -> LinkMap:
     COMMON  = 0

--- a/smol/parse.py
+++ b/smol/parse.py
@@ -149,11 +149,16 @@ def get_needed_syms(readelf_bin, inpfile) -> Dict[str, str]: # (symname, relocty
     return syms#, needgot
 
 
+def uniq_list(l):
+    od = OrderedDict()
+    for x in l: od[x] = x
+    return list(od.keys())
+
 def format_cc_path_line(entry):
     category, path = entry.split(': ', 1)
     path = path.lstrip('=')
-    return (category, list(set(os.path.realpath(p) \
-        for p in path.split(':') if os.path.isdir(p))))
+    return (category, uniq_list(os.path.realpath(p) \
+        for p in path.split(':') if os.path.isdir(p))[::-1])
 
 
 def get_cc_paths(cc_bin):

--- a/smol/parse.py
+++ b/smol/parse.py
@@ -279,19 +279,20 @@ def build_symbol_map(readelf_bin, libraries) -> Dict[str, Dict[str, ExportSym]]:
 # this ordening is specific to ONE symbol!
 def build_preferred_lib_order(sym, libs: Dict[str, ExportSym]) -> List[Tuple[str, ExportSym]]:
     # libs: lib -> syminfo
-    realdefs    = [(k, v) for k, v in libs.items() if v.scope != "WEAK"]
+    realdefs    = [(k, v) for k, v in libs.items() if v.scope != "WEAK" and v.ndx != "UND"]
     weakdefs    = [(k, v) for k, v in libs.items() if v.scope == "WEAK" and v.ndx != "UND"]
     weakunddefs = [(k, v) for k, v in libs.items() if v.scope == "WEAK" and v.ndx == "UND"]
+    unddefs     = [(k, v) for k, v in libs.items() if v.scope != "WEAK" and v.ndx == "UND"]
 
     #assert len(realdefs) + len(weakdefs) + len(weakunddefs) == len(libs)
 
     if len(realdefs) > 1 or (len(realdefs) == 0 and len(weakdefs) > 1):
         error("E: symbol '%s' defined non-weakly in multiple libraries! (%s)"
               % (sym, ', '.join(libs.keys())))
-    if len(realdefs) == 0 and len(weakdefs) == 0: # must be in weakunddefs
+    if len(realdefs) == 0 and len(weakdefs) == 0: # must be in weakunddefs or unddefs
         error("E: no default weak implementation found for symbol '%s'" % sym)
 
-    return realdefs + weakdefs + weakunddefs
+    return realdefs + weakdefs + weakunddefs #+ unddefs
 
 def has_good_subordening(needles, haystack):
     haylist = [x[0] for x in haystack]

--- a/smol/parse.py
+++ b/smol/parse.py
@@ -169,7 +169,7 @@ def list_symbols(readelf_bin, lib):
         if vis != "DEFAULT" or ndx == "UND":
             continue
 
-        # strip away GNU versions
+        # strip away GLIBC versions
         symbol = re.sub(r"@@.*$", "", symbol)
         symbols.append(symbol)
 
@@ -182,7 +182,7 @@ def build_symbol_map(readelf_bin, libraries):
         symbols = list_symbols(readelf_bin, lib)
         for symbol in symbols:
             if symbol not in symbol_map:
-                symbol_map[symbol] = []
+                symbol_map[symbol] = set()
             soname = lib.split("/")[-1]
-            symbol_map[symbol].append(soname)
+            symbol_map[symbol].add(soname)
     return symbol_map

--- a/smol/parse.py
+++ b/smol/parse.py
@@ -397,7 +397,7 @@ def resolve_extern_symbols(needed: Dict[str, List[str]], # symname -> reloctyps
                 message = "W: unreconcilable library ordenings '%s' and '%s' "+\
                     "for symbol '%s', you might want to enable `-fskip-zero-value'."
             if message is not None:
-                #eprintf(message % (', '.join(liborder.keys()), ', '.join(preferred.keys()), k))
+                eprintf(message % (', '.join(liborder.keys()), ', '.join(preferred.keys()), k))
 
         liborder = add_with_ordening(liborder, preferred, k, reloc)
         #eprintf("new order",visable(liborder),"\n")

--- a/smol/parse.py
+++ b/smol/parse.py
@@ -1,19 +1,38 @@
 
 import glob
 import os.path
+import re
 import subprocess
 import struct
 import sys
-import re
+from typing import NamedTuple, List, Dict, OrderedDict, Tuple, Set
 
 from .shared import *
 
+
+implicit_syms = { '_GLOBAL_OFFSET_TABLE_' }
+unsupported_symtyp = { 'NOTYPE', 'TLS', 'OBJECT' } # TODO: support OBJECT, and maybe TLS too
+
+
+class ExportSym(NamedTuple):
+    name: str
+    typ: str
+    scope: str
+    vis: str
+    ndx: str
+
+
 def decide_arch(inpfiles):
-    archs=set({})
+    archs = set()
 
     for fp in inpfiles:
         with open(fp, 'rb') as ff:
-            _ = ff.read(16) # ei_ident
+            magi = ff.read(4) # EI_MAGx of ei_ident
+
+            if magi != b'\x7fELF':
+                error("Input file '%s' is not an ELF file!" % fp)
+
+            _ = ff.read(12) # rest of ei_ident
             _ = ff.read( 2) # ei_type
             machine = ff.read(2) # ei_machine
 
@@ -23,30 +42,42 @@ def decide_arch(inpfiles):
     if len(archs) != 1:
         error("Input files have multiple architectures, can't link this...")
 
-    archn = list(archs)[0]
+    archn = archs.pop()
 
     if archn not in archmagic:
-        eprintf("Unknown architecture number " + str(archn) + \
-            ". Consult elf.h and rebuild your object files.")
+        eprintf("Unknown architecture number %d" + \
+            ". Consult elf.h and rebuild your object files." % archn)
 
     return archmagic[archn]
 
-def build_reloc_typ_table(reo):
-    relocs = dict({})
+
+def build_reloc_typ_table(reo) -> Dict[str, Set[str]]: # (symname, reloctyps) dict
+    relocs = {}
 
     for s in reo.decode('utf-8').splitlines():
         stuff = s.split()
 
         # prolly a 'header' line
-        if len(stuff) < 5:
+        if len(stuff) != 7 and len(stuff) != 5:
             continue
 
-        # yes, we're assuming every reference to the same symbol will use the
-        # same relocation type. if this isn't the case, your compiler flags are
-        # stupid
-        relocs[stuff[4]] = stuff[2]
+        symname, reloctyp = stuff[4], stuff[2]
+
+        if symname[0] == '.': # bleh
+            continue
+
+        relocs.setdefault(symname, set()).add(reloctyp)
+        # don't do that here, only check for import/external symbols (in get_needed_syms)
+        #if symname in relocs:
+        #    rlc = relocs[symname]
+        #    if rlc != reloctyp:
+        #        error("E: symbol '%s' used with multiple relocation types! (%s <-> %s)"
+        #              % (symname, reloctyp, rlc))
+        #else:
+        #    relocs[symname] = reloctyp
 
     return relocs
+
 
 def has_lto_object(readelf_bin, files):
     for x in files:
@@ -60,32 +91,55 @@ def has_lto_object(readelf_bin, files):
     curfile = files[0]
     for entry in output.decode('utf-8').splitlines():
         stuff = entry.split()
-        if len(stuff)<2: continue
-        if stuff[0] == "File:": curfile = stuff[1]
-        if "__gnu_lto_" in entry or ".gnu.lto" in entry: # assuming nobody uses a symbol called "__gnu_lto_" ...
+        if len(stuff) < 2:
+            continue
+        if stuff[0] == "File:":
+            curfile = stuff[1]
+
+        # assuming nobody uses a symbol called "__gnu_lto_"...
+        if "__gnu_lto_" in entry or ".gnu.lto" in entry:
             return True
+
     return False
 
-def get_needed_syms(readelf_bin, inpfile):
+
+def get_needed_syms(readelf_bin, inpfile) -> Dict[str, str]: # (symname, reloctyp) dict
     output = subprocess.check_output([readelf_bin, '-s', '-W',inpfile],
                                      stderr=subprocess.DEVNULL)
     outrel = subprocess.check_output([readelf_bin, '-r', '-W',inpfile],
                                      stderr=subprocess.DEVNULL)
+    #eprintf(output.decode('utf-8'))
+    #eprintf(outrel.decode('utf-8'))
 
     relocs = build_reloc_typ_table(outrel)
 
     curfile = inpfile
-    syms=set({})
+    syms = {}
     for entry in output.decode('utf-8').splitlines():
         stuff = entry.split()
-        if len(stuff)<2: continue
-        if stuff[0] == "File:": curfile = stuff[1]
-        if len(stuff)<8: continue
-        #if stuff[7].startswith("__gnu_lto_"): # yikes, an LTO object
-        #    error("{} is an LTO object file, can't use this!".format(curfile))
-        if stuff[4] == "GLOBAL" and stuff[6] == "UND" and len(stuff[7])>0 \
-                and stuff[7] in relocs:
-            syms.add((stuff[7], relocs[stuff[7]]))
+        if len(stuff) < 2:
+            continue
+        if stuff[0] == "File:":
+            curfile = stuff[1]
+        if len(stuff) < 8:
+            continue
+
+        scope, ndx, name = stuff[4], stuff[6], stuff[7]
+
+        if name.startswith("__gnu_lto_"): # yikes, an LTO object
+            error("E: {} is an LTO object file, can't use this!".format(curfile))
+        if scope == "GLOBAL" and ndx == "UND" and len(name) > 0:
+            if name in relocs:
+                rlt = relocs[name]
+                if len(rlt) > 1:
+                    error("E: symbol '%s' has multiple relocations types?! (%s)"
+                          % (name, ', '.join(rlt)))
+                #syms.add((name, rlt.pop()))
+                if name in syms:
+                    assert False, ("??? %s" % name)
+                syms[name] = rlt.pop()
+            elif name not in implicit_syms:
+                error("E: symbol '%s' has no relocation type?!" % name)
 
     #needgot = False
     #if "_GLOBAL_OFFSET_TABLE_" in syms:
@@ -94,11 +148,13 @@ def get_needed_syms(readelf_bin, inpfile):
 
     return syms#, needgot
 
+
 def format_cc_path_line(entry):
     category, path = entry.split(': ', 1)
     path = path.lstrip('=')
     return (category, list(set(os.path.realpath(p) \
         for p in path.split(':') if os.path.isdir(p))))
+
 
 def get_cc_paths(cc_bin):
     bak = os.environ.copy()
@@ -122,6 +178,7 @@ def get_cc_paths(cc_bin):
 
     return paths
 
+
 def get_cc_version(cc_bin):
     bak = os.environ.copy()
     os.environ['LANG'] = "C" # DON'T output localized search dirs!
@@ -137,22 +194,29 @@ def get_cc_version(cc_bin):
         verstr = lines[0].split()[-1]
         return ("clang", tuple(map(int, verstr.split('.'))))
 
+
 def is_valid_elf(f): # Good Enough(tm)
-    with open(f, 'rb') as ff: return ff.read(4) == b'\x7FELF'
+    with open(f, 'rb') as ff:
+        return ff.read(4) == b'\x7FELF'
+
 
 def find_lib(spaths, wanted):
     for p in spaths:
-        for f in glob.glob(glob.escape(p + '/lib' + wanted) + '.so*'):
-            if os.path.isfile(f) and is_valid_elf(f): return f
-        for f in glob.glob(glob.escape(p + '/'    + wanted) + '.so*'):
-            if os.path.isfile(f) and is_valid_elf(f): return f
+        for f in glob.glob(glob.escape('%s/lib%s' % (p, wanted)) + '.so*'):
+            if os.path.isfile(f) and is_valid_elf(f):
+                return f
+        for f in glob.glob(glob.escape('%s/%s'    % (p, wanted)) + '.so*'):
+            if os.path.isfile(f) and is_valid_elf(f):
+                return f
         #for f in glob.glob(glob.escape(p) + '/lib' + wanted + '.a' ): return f
         #for f in glob.glob(glob.escape(p) + '/'    + wanted + '.a' ): return f
 
-    error("E: couldn't find library '" + wanted + "'.")
+    error("E: couldn't find library '%s'." % wanted)
+
 
 def find_libs(spaths, wanted):
     return [find_lib(spaths, l) for l in wanted]
+
 
 def list_symbols(readelf_bin, lib):
     out = subprocess.check_output([readelf_bin, '-sW', lib], stderr=subprocess.DEVNULL)
@@ -175,14 +239,154 @@ def list_symbols(readelf_bin, lib):
 
     return symbols
 
-def build_symbol_map(readelf_bin, libraries):
-    # create dictionary that maps symbols to libraries that provide them
-    symbol_map = {}
-    for lib in libraries:
-        symbols = list_symbols(readelf_bin, lib)
-        for symbol in symbols:
-            if symbol not in symbol_map:
-                symbol_map[symbol] = set()
-            soname = lib.split("/")[-1]
-            symbol_map[symbol].add(soname)
+
+def build_symbol_map(readelf_bin, libraries) -> Dict[str, Dict[str, ExportSym]]:
+    # create dictionary that maps symbols to libraries that provide them, and their metadata
+    symbol_map = {} # symname -> (lib, exportsym)
+
+    out = subprocess.check_output([readelf_bin, '-sW', *libraries], stderr=subprocess.DEVNULL)
+
+    lines = out.decode('utf-8').splitlines()
+    curfile = libraries[0]
+    soname  = curfile.split("/")[-1]
+    for line in lines:
+        fields = line.split()
+        if len(fields) < 2:
+            continue
+        if fields[0] == "File:":
+            curfile = fields[1]
+            soname  = curfile.split("/")[-1]
+
+        if len(fields) != 8:
+            continue
+
+        typ, scope, vis, ndx, name = fields[3:8]
+        if vis != "DEFAULT" \
+                or scope == "LOCAL": #\
+                #or (ndx == "UND" and scope != "WEAK"):# \ # nah, that one's done further down the line as well
+                #or typ in unsupported_symtym:
+                # ^ except, for the last case, we're going to emit proper errors later on
+            continue
+
+        # strip away GLIBC versions
+        name = re.sub(r"@@.*$", "", name)
+
+        symbol_map.setdefault(name, {})[soname] = ExportSym(name, typ, scope, vis, ndx)
+
     return symbol_map
+
+
+# this ordening is specific to ONE symbol!
+def build_preferred_lib_order(sym, libs: Dict[str, ExportSym]) -> List[Tuple[str, ExportSym]]:
+    # libs: lib -> syminfo
+    realdefs    = [(k, v) for k, v in libs.items() if v.scope != "WEAK"]
+    weakdefs    = [(k, v) for k, v in libs.items() if v.scope == "WEAK" and v.ndx != "UND"]
+    weakunddefs = [(k, v) for k, v in libs.items() if v.scope == "WEAK" and v.ndx == "UND"]
+
+    #assert len(realdefs) + len(weakdefs) + len(weakunddefs) == len(libs)
+
+    if len(realdefs) > 1 or (len(realdefs) == 0 and len(weakdefs) > 1):
+        error("E: symbol '%s' defined non-weakly in multiple libraries! (%s)"
+              % (sym, ', '.join(libs.keys())))
+    if len(realdefs) == 0 and len(weakdefs) == 0: # must be in weakunddefs
+        error("E: no default weak implementation found for symbol '%s'" % sym)
+
+    return realdefs + weakdefs + weakunddefs
+
+def has_good_subordening(needles, haystack):
+    haylist = [x[0] for x in haystack]
+    prevind = 0
+    for k, _ in needles:
+        curind = None
+        try:
+            curind = haylist.index(k)
+        except ValueError: # not in haystack --> eh, let's ignore
+            continue
+
+        if curind < prevind:
+            return False
+        prevind = curind
+    return True
+
+def add_with_ordening(haystack: List[Tuple[str, Dict[str, str]]], # [(libname, (symname -> reloctyp))]
+                      needles: List[Tuple[str, ExportSym]], # [(lib, syminfo)]
+                      sym: str, reloc: str) \
+                   -> List[Tuple[str, Dict[str, str]]]:
+    haylist = [x[0] for x in haystack]
+    startind = 0
+    for k, v in needles:
+        #eprintf("k=",k,"v=",v)
+        try:
+            newind = haylist.index(k)
+            assert newind >= startind, "???? (%d <= %d)" % (newind, startind)
+            startind = newind
+
+            symrelocdict = haystack[startind][1]
+            if v.name in symrelocdict:
+                assert False, "?????"
+            haystack[startind][1][v.name] = reloc
+        except ValueError: # not in haystack --> add!
+            startind = startind + 1
+            haystack.insert(startind, (k, {v.name:reloc}))
+            haylist.insert(startind, k)
+
+    return haystack
+
+def resolve_extern_symbols(needed: Dict[str, List[str]], # symname -> reloctyps
+                           available: Dict[str, Dict[str, ExportSym]], # symname -> (lib -> syminfo)
+                           args) \
+                        -> OrderedDict[str, Dict[str, str]]: # libname -> (symname -> reloctyp)
+    # first of all, we're going to check which needed symbols are provided by
+    # which libraries
+    bound = {} # sym -> (reloc, (lib -> syminfo))
+    for k, v in needed.items():
+        if k not in available:
+            error("E: symbol '%s' could not be found." % k)
+
+        bound[k] = (v, available[k])
+
+    # default ordening
+    bound = bound.items()
+    if args.det:
+        bound = sorted(bound, key=lambda kv: (len(kv[0]), kv[0]))
+
+    #eprintf("bound", bound)
+
+    liborder = [] # [(libname, (symname -> reloctyp))]
+    for k, v in bound: # k: sym (str)
+        # reloc: str
+        # libs: lib -> syminfo
+        reloc, libs = v[0], v[1]
+        if len(libs) <= 1:
+            continue
+        # preferred: [(lib, syminfo)]
+        preferred = build_preferred_lib_order(k, libs)
+        #eprintf("preferred",preferred)
+        if not has_good_subordening(preferred, liborder):
+            message = None
+            if args.fuse_dnload_loader and not args.fskip_zero_value:
+                message = "W: unreconcilable library ordenings '%s' and '%s' "+\
+                    "for symbol '%s', you are STRONGLY advised to use `-fskip-zero-value'!"
+            if not args.fuse_dnload_loader and not args.fskip_zero_value:
+                message = "W: unreconcilable library ordenings '%s' and '%s' "+\
+                    "for symbol '%s', you might want to enable `-fskip-zero-value'."
+            if message is not None:
+                eprintf(message % (', '.join(liborder.keys()), ', '.join(preferred.keys()), k))
+
+        liborder = add_with_ordening(liborder, preferred, k, reloc)
+        #eprintf("new order",liborder)
+
+    # add all those left without any possible preferred ordening
+    for k, v in bound:
+        reloc, libs = v[0], v[1]
+        if len(libs) == 0:
+            assert False, ("??? (%s)" % sym)
+        if len(libs) != 1:
+            continue
+        lib = libs.popitem() # (lib, syminfo)
+        liborder = add_with_ordening(liborder, [lib], k, reloc)
+        #eprintf("new order (no preference)",liborder)
+
+    #eprintf("ordered", liborder)
+    return OrderedDict(liborder)
+

--- a/smol/shared.py
+++ b/smol/shared.py
@@ -14,7 +14,7 @@ HASH_BSD2 = 1
 HASH_CRC32C=2
 
 define_for_hash = {
-    HASH_DJB2: None
+    HASH_DJB2: None,
     HASH_BSD2: 'USE_HASH16',
     HASH_CRC32C: 'USE_CRC32C_HASH'
 }
@@ -35,9 +35,16 @@ def hash_djb2(s):
 
 
 def hash_crc32c(s):
-    # crc32 implementation is basically:
-    # sum = -1; for (; *s; ++s) crc32_instr(&sum, *s); return sum
-    assert False, "not implemented!" # TODO
+    crc = 0x0
+    for c in s:
+        k = (crc & 0xff) ^ ord(c)
+        for i in range(8):
+            j = k & 1
+            if j == 1:
+                k ^= 0x105EC76F0
+            k >>= 1
+        crc = ((crc >> 8) ^ k) & 0xFFFFFFFF
+    return crc
 
 
 def eprintf(*args, **kwargs):

--- a/smol/shared.py
+++ b/smol/shared.py
@@ -9,6 +9,16 @@ archmagic = {
     'x86_64': 62, 62: 'x86_64',
 }
 
+HASH_DJB2 = 0
+HASH_BSD2 = 1
+HASH_CRC32C=2
+
+define_for_hash = {
+    HASH_DJB2: None
+    HASH_BSD2: 'USE_HASH16',
+    HASH_CRC32C: 'USE_CRC32C_HASH'
+}
+
 
 def hash_bsd2(s):
     h = 0
@@ -24,8 +34,29 @@ def hash_djb2(s):
     return h
 
 
+def hash_crc32c(s):
+    # crc32 implementation is basically:
+    # sum = -1; for (; *s; ++s) crc32_instr(&sum, *s); return sum
+    assert False, "not implemented!" # TODO
+
+
 def eprintf(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
+
+
+def get_hash_id(h16, c32):
+    if not h16 and not c32:
+        return HASH_DJB2
+    elif h16 and not c32:
+        return HASH_BSD2
+    elif not h16 and c32:
+        return HASH_CRC32C
+    else:
+        return False, "??????? (shouldn't happen)"
+
+
+def get_hash_fn(hid):
+    return (hash_djb2, hash_bsd2, hash_crc32c)[hid]
 
 
 def error(*args, **kwargs):

--- a/smol/shared.py
+++ b/smol/shared.py
@@ -1,5 +1,7 @@
 
 import sys
+import traceback
+
 
 archmagic = {
     'i386':    3,  3: 'i386'  ,
@@ -7,11 +9,13 @@ archmagic = {
     'x86_64': 62, 62: 'x86_64',
 }
 
+
 def hash_bsd2(s):
     h = 0
     for c in s:
         h = ((h >> 2) + ((h & 3) << 14) + ord(c)) & 0xFFFF
     return h
+
 
 def hash_djb2(s):
     h = 5381
@@ -19,9 +23,13 @@ def hash_djb2(s):
         h = (h * 33 + ord(c)) & 0xFFFFFFFF
     return h
 
-def eprintf(*args, **kwargs): print(*args, file=sys.stderr, **kwargs)
+
+def eprintf(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
 
 def error(*args, **kwargs):
+    traceback.print_stack()
     eprintf(*args, **kwargs)
     sys.exit(1)
 

--- a/smold.py
+++ b/smold.py
@@ -37,6 +37,9 @@ def main():
     parser.add_argument('-d', '--det', default=False, action='store_true', \
         help="Make the order of imports deterministic (default: just use " + \
              "whatever binutils throws at us)")
+    parser.add_argument('-g', '--debug', default=False, action='store_true', \
+        help="Pass `-g' to the C compiler, assembler and linker. Only useful "+\
+             "when `--debugout' is specified.")
 
     parser.add_argument('-fuse-interp', default=True, action='store_true', \
         help="[Default ON] Include a program interpreter header (PT_INTERP). If not " +\
@@ -142,6 +145,11 @@ def main():
 
     if args.hash16 and args.crc32c: # shouldn't happen anymore
         error("Cannot combine --hash16 and --crc32c!")
+
+    if args.debug:
+        args.cflags.append('-g')
+        args.ldflags.append('-g')
+        args.asflags.append('-g')
 
     if args.hash16 or args.crc32c:
         args.fuse_dnload_loader = True

--- a/smold.py
+++ b/smold.py
@@ -177,7 +177,7 @@ def main():
             libs_for_symbol = libs_symbol_map[symbol]
             if len(libs_for_symbol) > 1:
                 error("E: the symbol '" + symbol + "' is provided by more than one library: " + str(libs_for_symbol))
-            library = libs_for_symbol[0]
+            library = libs_for_symbol.pop()
             symbols.setdefault(library, [])
             symbols[library].append((symbol, reloc))
 

--- a/smold.py
+++ b/smold.py
@@ -137,6 +137,9 @@ def main():
         help="Write out an additional, unrunnable debug ELF file with symbol "+\
              "information. (Useful for debugging with gdb, cannot be ran due "+\
              "to broken relocations.)")
+    parser.add_argument('--hang-on-startup', default=False, action='store_true', \
+        help="Hang on startup until a debugger breaks the code out of the "+\
+             "loop. Only useful for debugging.")
 
     parser.add_argument('input', nargs='+', help="input object file")
     parser.add_argument('output', type=str, help="output binary")
@@ -168,6 +171,7 @@ def main():
     if args.falign_stack: args.asflags.insert(0, "-DALIGN_STACK")
     if args.fifunc_support: args.asflags.insert(0, "-DIFUNC_SUPPORT")
     if args.fifunc_strict_cconv: args.asflags.insert(0, "-DIFUNC_CORRECT_CCONV")
+    if args.hang_on_startup: args.asflags.insert(0, "-DHANG_ON_STARTUP")
 
     for x in ['nasm','cc','readelf']:
         val = args.__dict__[x]

--- a/smold.py
+++ b/smold.py
@@ -76,7 +76,10 @@ def main():
              "so only enable this if you're sure this won't break things!")
     parser.add_argument('-fifunc-support', default=False, action='store_true', \
         help="Support linking to IFUNCs. Probably needed on x86_64, but costs "+\
-             "~16 bytes. Ignored on platforms other than x86_64 or aarch64.")
+             "~16 bytes. Ignored on platforms without IFUNC support.")
+    parser.add_argument('-fifunc-strict-cconv', default=False, action='store_true', \
+        help="On i386, if -fifunc-support is specified, strictly follow the "+\
+             "calling convention rules. Probably not needed, but you never know.")
 
     parser.add_argument('--nasm', default=os.getenv('NASM') or shutil.which('nasm'), \
         help="which nasm binary to use")
@@ -126,6 +129,7 @@ def main():
     if args.fuse_interp: args.asflags.insert(0, "-DUSE_INTERP")
     if args.falign_stack: args.asflags.insert(0, "-DALIGN_STACK")
     if args.fifunc_support: args.asflags.insert(0, "-DIFUNC_SUPPORT")
+    if args.fifunc_strict_cconv: args.asflags.insert(0, "-DIFUNC_CORRECT_CCONV")
 
     for x in ['nasm','cc','scanelf','readelf']:
         val = args.__dict__[x]

--- a/smold.py
+++ b/smold.py
@@ -36,12 +36,12 @@ def main():
         help="Make the order of imports deterministic (default: just use " + \
              "whatever binutils throws at us)")
 
-    parser.add_argument('-fuse-interp', default=False, action='store_true', \
-        help="Include a program interpreter header (PT_INTERP). If not " +\
+    parser.add_argument('-fno-use-interp', default=False, action='store_true', \
+        help="Don't include a program interpreter header (PT_INTERP). If not " +\
              "enabled, ld.so has to be invoked manually by the end user.")
-    parser.add_argument('-falign-stack', default=False, action='store_true', \
-        help="Align the stack before running user code (_start). If not " + \
-             "enabled, this has to be done manually. Costs 1 byte.")
+    parser.add_argument('-fno-align-stack', default=False, action='store_true', \
+        help="Don't align the stack before running user code (_start). If not " + \
+             "enabled, this has to be done manually. Frees 1 byte.")
     parser.add_argument('-fuse-nx', default=False, action='store_true', \
         help="Don't use one big RWE segment, but use separate RW and RE ones."+\
              " Use this to keep strict kernels (PaX/grsec) happy. Costs at "+\
@@ -51,11 +51,11 @@ def main():
              "depend on nonstandard/undocumented ELF and ld.so features, but "+\
              "is slightly larger. If not enabled, a smaller custom loader is "+\
              "used which assumes glibc.")
-    parser.add_argument('-fskip-zero-value', default=False, action='store_true', \
-        help="Skip an ELF symbol with a zero address (a weak symbol) when "+\
+    parser.add_argument('-fno-skip-zero-value', default=False, action='store_true', \
+        help="Don't skip an ELF symbol with a zero address (a weak symbol) when "+\
              "parsing libraries at runtime. Try enabling this if you're "+\
              "experiencing sudden breakage. However, many libraries don't use "+\
-             "weak symbols, so this doesn't often pose a problem. Costs ~5 bytes.")
+             "weak symbols, so this doesn't often pose a problem. Frees ~5 bytes.")
     parser.add_argument('-fuse-dt-debug', default=False, action='store_true', \
         help="Use the DT_DEBUG Dyn header to access the link_map, which doesn't"+\
              " depend on nonstandard/undocumented ELF and ld.so features. If "+\
@@ -77,7 +77,7 @@ def main():
         help="Don't end the ELF Dyn table with a DT_NULL entry. This might "+\
              "cause ld.so to interpret the entire binary as the Dyn table, "+\
              "so only enable this if you're sure this won't break things!")
-    parser.add_argument('-fifunc-support', default=False, action='store_true', \
+    parser.add_argument('-fno-ifunc-support', default=True, action='store_true', \
         help="Support linking to IFUNCs. Probably needed on x86_64, but costs "+\
              "~16 bytes. Ignored on platforms without IFUNC support.")
     parser.add_argument('-fifunc-strict-cconv', default=False, action='store_true', \
@@ -125,7 +125,7 @@ def main():
     if args.hash16 or args.crc32c:
         args.fuse_dnload_loader = True
 
-    if args.fskip_zero_value: args.asflags.insert(0, "-DSKIP_ZERO_VALUE")
+    if not args.fno_skip_zero_value: args.asflags.insert(0, "-DSKIP_ZERO_VALUE")
     if args.fuse_nx: args.asflags.insert(0, "-DUSE_NX")
     if args.fskip_entries: args.asflags.insert(0, "-DSKIP_ENTRIES")
     if args.funsafe_dynamic: args.asflags.insert(0, "-DUNSAFE_DYNAMIC")
@@ -133,9 +133,9 @@ def main():
     if args.fuse_dl_fini: args.asflags.insert(0, "-DUSE_DL_FINI")
     if args.fuse_dt_debug: args.asflags.insert(0, "-DUSE_DT_DEBUG")
     if args.fuse_dnload_loader: args.asflags.insert(0, "-DUSE_DNLOAD_LOADER")
-    if args.fuse_interp: args.asflags.insert(0, "-DUSE_INTERP")
-    if args.falign_stack: args.asflags.insert(0, "-DALIGN_STACK")
-    if args.fifunc_support: args.asflags.insert(0, "-DIFUNC_SUPPORT")
+    if not args.fno_use_interp: args.asflags.insert(0, "-DUSE_INTERP")
+    if not args.fno_align_stack: args.asflags.insert(0, "-DALIGN_STACK")
+    if not args.fno_ifunc_support: args.asflags.insert(0, "-DIFUNC_SUPPORT")
     if args.fifunc_strict_cconv: args.asflags.insert(0, "-DIFUNC_CORRECT_CCONV")
 
     for x in ['nasm','cc','readelf']:

--- a/smold.py
+++ b/smold.py
@@ -120,11 +120,11 @@ def do_smol_run(args, arch):
                                  tmp_asm_file, tmp_elf_file, args.asflags)
 
             # link with LD into the final executable, w/ special linker script
-            ld_link_final(args.verbose, args.cc, arch, args.smolld, [objinput, tmp_elf_file],
-                          args.output, args.ldflags, False)
-            if args.debugout is not None:
+            if args.debugout is not None: # do this first, so the linker map output will use the final output binary
                 ld_link_final(args.verbose, args.cc, arch, args.smolld, [objinput, tmp_elf_file],
                               args.debugout, args.ldflags, True)
+            ld_link_final(args.verbose, args.cc, arch, args.smolld, [objinput, tmp_elf_file],
+                          args.output, args.ldflags, False)
     finally:
         if not args.keeptmp:
             if objinputistemp: os.remove(objinput)

--- a/smold.py
+++ b/smold.py
@@ -24,8 +24,11 @@ def main():
         help="directories to search libraries in")
 
     parser.add_argument('-s', '--hash16', default=False, action='store_true', \
-        help="Use 16-bit (BSD) hashes instead of 32-bit djb2 hashes. "+\
-             "Implies -fuse-dnload-loader")
+        help="Use 16-bit (BSD2) hashes instead of 32-bit djb2 hashes. "+\
+             "Implies -fuse-dnload-loader. Only usable for 32-bit output.")
+    parser.add_argument('-c', '--crc32c', default=False, action='store_true', \
+        help="Use Intel's crc32 intrinsic for hashing. "+\
+             "Implies -fuse-dnload-loader. Conflicts with `--hash16'.")
     parser.add_argument('-n', '--nx', default=False, action='store_true', \
         help="Use NX (i.e. don't use RWE pages). Costs the size of one phdr, "+\
              "plus some extra bytes on i386.")
@@ -118,7 +121,10 @@ def main():
 
     args = parser.parse_args()
 
-    if args.hash16:
+    if args.hash16 and args.crc32c:
+        error("Cannot combine --hash16 and --crc32c!")
+
+    if args.hash16 or args.crc32c:
         args.fuse_dnload_loader = True
 
     if args.fskip_zero_value: args.asflags.insert(0, "-DSKIP_ZERO_VALUE")
@@ -144,6 +150,9 @@ def main():
     if arch not in archmagic:
         error("Unknown/unsupported architecture '%s'" % str(arch))
     if args.verbose: eprintf("arch: %s" % str(arch))
+
+    if args.hash16 and arch not in ('i386', 3):
+        error("Cannot use --hash16 for arch `%s' (not i386)" % (arch))
 
     objinput = None
     objinputistemp = False
@@ -180,7 +189,7 @@ def main():
             symbols[library].append((symbol, reloc))
 
         with os.fdopen(tmp_asm_fd, mode='w') as taf:
-            output(arch, symbols, args.nx, args.hash16, taf, args.det)
+            output(arch, symbols, args.nx, get_hash_id(args.hash16, args.crc32c), taf, args.det)
             if args.verbose:
                 eprintf("wrote symtab to %s" % tmp_asm_file)
 

--- a/smoldd.py
+++ b/smoldd.py
@@ -127,11 +127,16 @@ def get_hashtbl(elf, blob, args):
             #eprintf("htoff = 0x%08x, len=%08x" % (htoff, len(blob)))
             if len(blob) <= htoff and len(tbl) > 0:
                 break
+            #if elf.is32bit:
             if struct.unpack('<B', blob[htoff:htoff+1])[0] == 0:
                 break
+            #else:
+            #    if struct.unpack('<H', blob[htoff:htoff+2])[0] == 0:
+            #        break
         val = struct.unpack('<I', blob[htoff:htoff+4])[0]
-        if (val & 0xFF) == 0: break
+        if (val & 0xFFFF) == 0: break
         tbl.append(val)
+        #eprintf("sym %08x" % val)
         htoff = htoff + (4 if elf.is32bit else 8)
 
     return tbl

--- a/smoldd.py
+++ b/smoldd.py
@@ -209,5 +209,5 @@ if __name__ == '__main__':
     if rv is None: pass
     else:
         try: sys.exit(int(rv))
-        except: sys.exit(1)
+        except Exception: sys.exit(1)
 

--- a/smoldd.py
+++ b/smoldd.py
@@ -153,10 +153,12 @@ def main():
                         "Get the address of the symbol hash table from the "+\
                         "linker map output instead of attempting to parse the"+\
                         " binary.")
-    parser.add_argument('-s', '--hash16', default=False, action='store_true', \
+
+    hashgrp = parser.add_mutually_exclusive_group()
+    hashgrp.add_argument('-s', '--hash16', default=False, action='store_true', \
         help="Use 16-bit (BSD2) hashes instead of 32-bit djb2 hashes. "+\
              "Implies -fuse-dnload-loader. Only usable for 32-bit output.")
-    parser.add_argument('-c', '--crc32c', default=False, action='store_true', \
+    hashgrp.add_argument('-c', '--crc32c', default=False, action='store_true', \
         help="Use Intel's crc32 intrinsic for hashing. "+\
              "Implies -fuse-dnload-loader. Conflicts with `--hash16'.")
     args = parser.parse_args()

--- a/smoldd.py
+++ b/smoldd.py
@@ -36,17 +36,18 @@ def find_libs(deflibs, libname):
     for d in dirs:
         for f in glob.glob(glob.escape(d + '/' + libname) + '*'): yield f
 
-def build_hashtab(scanelf_bin, lib):
+def build_hashtab(scanelf_bin, lib, hashid):
     out = subprocess.check_output([scanelf_bin, '-B', '-F', '%s', '-s', '%pd%*', lib],
                                      stderr=subprocess.DEVNULL)
 
     blah = set(out.decode('utf-8').split('\n'))
     ret = dict({})
 
+    hashfn = get_hash_fn(hashid)
     for x in blah:
         y = x.split()
         if len(y) != 7: continue
-        ret[hash_djb2(y[6])] = y[6]
+        ret[hashfn(y[6])] = y[6]
 
     return ret
 
@@ -153,6 +154,12 @@ def main():
                         "Get the address of the symbol hash table from the "+\
                         "linker map output instead of attempting to parse the"+\
                         " binary.")
+    parser.add_argument('-s', '--hash16', default=False, action='store_true', \
+        help="Use 16-bit (BSD2) hashes instead of 32-bit djb2 hashes. "+\
+             "Implies -fuse-dnload-loader. Only usable for 32-bit output.")
+    parser.add_argument('-c', '--crc32c', default=False, action='store_true', \
+        help="Use Intel's crc32 intrinsic for hashing. "+\
+             "Implies -fuse-dnload-loader. Conflicts with `--hash16'.")
     args = parser.parse_args()
 
     blob = args.input.read()
@@ -164,7 +171,8 @@ def main():
 
     htbl = get_hashtbl(elf, blob, args)
 
-    libhashes = dict((l, build_hashtab(args.scanelf, neededpaths[l])) for l in needed)
+    hashid = get_hash_id(args.hash16, args.crc32c)
+    libhashes = dict((l, build_hashtab(args.scanelf, neededpaths[l], hashid)) for l in needed)
 
     hashresolves = dict({})
     noresolves   = []

--- a/smoldd.py
+++ b/smoldd.py
@@ -157,10 +157,9 @@ def main():
     hashgrp = parser.add_mutually_exclusive_group()
     hashgrp.add_argument('-s', '--hash16', default=False, action='store_true', \
         help="Use 16-bit (BSD2) hashes instead of 32-bit djb2 hashes. "+\
-             "Implies -fuse-dnload-loader. Only usable for 32-bit output.")
+             "Only usable for 32-bit output.")
     hashgrp.add_argument('-c', '--crc32c', default=False, action='store_true', \
-        help="Use Intel's crc32 intrinsic for hashing. "+\
-             "Implies -fuse-dnload-loader. Conflicts with `--hash16'.")
+        help="Use Intel's crc32 intrinsic for hashing. Conflicts with `--hash16'.")
     args = parser.parse_args()
 
     blob = args.input.read()

--- a/smoldd.py
+++ b/smoldd.py
@@ -114,18 +114,26 @@ def get_hashtbl(elf, blob, args):
 
     tbl = []
     while True:
+        hashsz = 2 if elf.is32bit and args.hash16 else 4
+
         #eprintf("sym from 0x%08x" % htoff)
-        if len(blob)-htoff < 4:
+        #eprintf("sym end at 0x%08x, blob end at 0x%08x" % (htoff+hashsz, len(blob)))
+        if htoff+hashsz > len(blob):
             #eprintf("htoff = 0x%08x, len=%08x" % (htoff, len(blob)))
             if len(blob) <= htoff and len(tbl) > 0:
                 break
             #if elf.is32bit:
             if struct.unpack('<B', blob[htoff:htoff+1])[0] == 0:
                 break
+            else:
+                assert False, "AAAAA rest is %s" % repr(blob[htoff:])
             #else:
             #    if struct.unpack('<H', blob[htoff:htoff+2])[0] == 0:
             #        break
-        val = struct.unpack('<I', blob[htoff:htoff+4])[0]
+            #    else:
+            #        assert False, "AAAAA rest is %s" % repr(blob[htoff:])
+        val = struct.unpack(('<I' if hashsz == 4 else '<H'),
+                            blob[htoff:htoff+hashsz])[0]
         if (val & 0xFFFF) == 0: break
         tbl.append(val)
         #eprintf("sym %08x" % val)

--- a/test/hello.c
+++ b/test/hello.c
@@ -1,6 +1,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <math.h>
 
 const char *f = "foo";
 
@@ -10,6 +11,7 @@ int main(int argc, char* argv[]) {
     printf("argv=%p\n", (void*)argv);
     for (int i = 0; i < argc; ++i)
         printf("argv[%d](%p)=%s\n", i, (void*)argv[i], argv[i]);
+    printf("sin(%d)=%f\n", argc, sinf(argc));
     exit(42);
 }
 


### PR DESCRIPTION
Don't merge this immediately yet, currently asking around for some people to test.

---------

New features:
* (Optionally) output a separate ELF file with symbols and DWARF info
* Add new optional CRC32C hash function, to use the `crc32` instruction to do all the hashing
* Automatically detect smallest possible opcode for end-of-hash-list check
* Flag for reenabling prerelease "only output assembly file" behavior
* Add misc. debugging flags

Bugfixes:
* smol now properly checks whether the input files are actually ELFs
* smol correctly notices when symbols are used with more than one relocation type at once, and emits an error
* Handle IFUNCs properly
* Removed the dependency on `scanelf`
* smol now tries to find the correct ordening of libraries to avoid encountering weak symbols in the first place, and warns on their occurrence
* smoldd is now working again for use-dnload-loader and 32-bit binaries, and for binaries that don't use djb2 hashes
* Linker map parsing now has its data ordered by memory address

Documentation updates:
* Update notes on unsupported C++ stuff etc.
* Update flags listing
* Add a section on debugging smol-ified binaries

Breaking changes:
* Make some flags on-by-default instead of off-by-default